### PR TITLE
Fix keyboard event handling during composition

### DIFF
--- a/combobox-nav.js
+++ b/combobox-nav.js
@@ -1,7 +1,5 @@
 /* @flow strict */
 
-const compositionMap = new WeakMap()
-
 export function install(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): void {
   input.addEventListener('compositionstart', trackComposition)
   input.addEventListener('compositionend', trackComposition)
@@ -17,13 +15,14 @@ export function uninstall(input: HTMLTextAreaElement | HTMLInputElement, list: H
   list.removeEventListener('click', commitWithElement)
 }
 
+let isComposing = false
 const ctrlBindings = !!navigator.userAgent.match(/Macintosh/)
 
 function keyboardBindings(event: KeyboardEvent) {
   if (event.shiftKey || event.metaKey || event.altKey) return
   const input = event.currentTarget
   if (!(input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement)) return
-  if (compositionMap.get(input)) return
+  if (isComposing) return
   const list = document.getElementById(input.getAttribute('aria-owns') || '')
   if (!list) return
 
@@ -118,7 +117,7 @@ function clearSelection(list): void {
 function trackComposition(event: Event): void {
   const input = event.currentTarget
   if (!(input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement)) return
-  compositionMap.set(input, event.type === 'compositionstart')
+  isComposing = event.type === 'compositionstart'
 
   const list = document.getElementById(input.getAttribute('aria-owns') || '')
   if (!list) return

--- a/combobox-nav.js
+++ b/combobox-nav.js
@@ -30,8 +30,12 @@ function keyboardBindings(event: KeyboardEvent) {
   switch (event.key) {
     case 'Enter':
     case 'Tab':
-      commit(input, list)
-      event.preventDefault()
+      if (commit(input, list)) {
+        event.preventDefault()
+      }
+      break
+    case 'Escape':
+      clearSelection(list)
       break
     case 'ArrowDown':
       navigate(input, list, 1)
@@ -64,10 +68,11 @@ function commitWithElement(event: MouseEvent) {
   event.preventDefault()
 }
 
-function commit(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): void {
+function commit(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): boolean {
   const target = list.querySelector('[aria-selected="true"]')
-  if (!target) return
+  if (!target) return false
   fireCommitEvent(target)
+  return true
 }
 
 function fireCommitEvent(target: Element): void {
@@ -104,14 +109,19 @@ export function navigate(
   }
 }
 
-function trackComposition(event: Event) {
+function clearSelection(list): void {
+  const target = list.querySelector('[aria-selected="true"]')
+  if (!target) return
+  target.setAttribute('aria-selected', 'false')
+}
+
+function trackComposition(event: Event): void {
   const input = event.currentTarget
   if (!(input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement)) return
   compositionMap.set(input, event.type === 'compositionstart')
 
   const list = document.getElementById(input.getAttribute('aria-owns') || '')
   if (!list) return
-  const target = list.querySelector('[aria-selected="true"]')
-  if (!target) return
-  target.setAttribute('aria-selected', 'false')
+
+  clearSelection(list)
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -8,16 +8,18 @@
   <style>[aria-selected="true"] { font-weight: bold; }</style>
 </head>
 <body>
-  <label>
-    Least favorite robot
-    <input aria-owns="list-id" role="combobox" type="text">
-  </label>
-  <ul role="listbox" id="list-id">
-    <li id="baymax" role="option">Baymax</li>
-    <li><del>BB-8</del></li>
-    <li id="hubot" role="option">Hubot</li>
-    <li id="r2-d2" role="option">R2-D2</li>
-  </ul>
+  <form>
+    <label>
+      Least favorite robot
+      <input aria-owns="list-id" role="combobox" type="text">
+    </label>
+    <ul role="listbox" id="list-id">
+      <li id="baymax" role="option">Baymax</li>
+      <li><del>BB-8</del></li>
+      <li id="hubot" role="option">Hubot</li>
+      <li id="r2-d2" role="option">R2-D2</li>
+    </ul>
+  </form>
   <pre class="events"></pre>
   <script type="text/javascript">
     comboboxNav.install(document.querySelector('input'), document.querySelector('ul'))


### PR DESCRIPTION
This is to fix unintentional interaction during text compositions (IME), like this:

![](https://cl.ly/936c13a68d7c/Screen%252520Recording%2525202018-12-18%252520at%25252002.59%252520PM.gif)

- Prevent keyboard bindings during composition ([spec](https://www.w3.org/TR/uievents/#events-composition-key-events))
  This is tricky because:
  - Safari: [keydown happens after composition events 🐛](https://bugs.webkit.org/show_bug.cgi?id=165004)
  - Chrome: keydown happens before composition events
  - Firefox: [keydown does not happen during composition 🐛](https://bugzilla.mozilla.org/show_bug.cgi?id=1237214) ([spec](https://www.w3.org/TR/uievents/#events-composition-key-events))
- Clear selection upon `compositionstart` because ^ we can't rely on keydown Enter to be prevented during composition in Safari
- Support Escape to clear selection
- Only interfere with keydown Enter/Tab if item selection exists

After fix:

![](https://cl.ly/f08743f64b22/Screen%252520Recording%2525202018-12-18%252520at%25252003.00%252520PM.gif)

---

❤️ https://github.com/javan/input-inspector