### PR TITLE
Fix unpkg url in example

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>combobox-nav demo</title>
   <!-- <script type="text/javascript" src="../dist/combobox-nav.umd.js"></script> -->
-  <script type="text/javascript" src="https://unpkg.com/@github/combobox-nav@latest"></script>
+  <script type="text/javascript" src="https://unpkg.com/@github/combobox-nav@latest/dist/combobox-nav.umd.js"></script>
   <style>[aria-selected="true"] { font-weight: bold; }</style>
 </head>
 <body>


### PR DESCRIPTION
I noticed that the [example](https://github.github.io/combobox-nav/examples/) isn't working as the unpkg url is wrong.