### PR TITLE
Prevent disabled items from being committed

### DIFF
--- a/combobox-nav.js
+++ b/combobox-nav.js
@@ -69,7 +69,7 @@ function commitWithElement(event: MouseEvent) {
 
 function commit(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): boolean {
   const target = list.querySelector('[aria-selected="true"]')
-  if (!target) return false
+  if (!target || target.getAttribute('aria-disabled') === 'true') return false
   fireCommitEvent(target)
   return true
 }

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,7 @@ describe('combobox-nav', function() {
           <li><del>BB-8</del></li>
           <li id="hubot" role="option">Hubot</li>
           <li id="r2-d2" role="option">R2-D2</li>
+          <li id="wall-e" role="option" aria-disabled="true">Wall-E</li>
         </ul>
       `
       comboboxNav.install(document.querySelector('input'), document.querySelector('ul'))
@@ -79,18 +80,23 @@ describe('combobox-nav', function() {
       assert.equal(options[3].getAttribute('aria-selected'), 'true')
       assert.equal(input.getAttribute('aria-activedescendant'), 'r2-d2')
 
+      press(input, 'n', true)
+      assert.equal(options[4].getAttribute('aria-selected'), 'true')
+      assert.equal(input.getAttribute('aria-activedescendant'), 'wall-e')
+      press(input, 'Enter')
+
       press(input, 'p', true)
-      assert.equal(options[2].getAttribute('aria-selected'), 'true')
-      assert.equal(input.getAttribute('aria-activedescendant'), 'hubot')
+      assert.equal(options[3].getAttribute('aria-selected'), 'true')
+      assert.equal(input.getAttribute('aria-activedescendant'), 'r2-d2')
 
       press(input, 'ArrowUp')
-      assert.equal(options[0].getAttribute('aria-selected'), 'true')
-      assert.equal(input.getAttribute('aria-activedescendant'), 'baymax')
+      assert.equal(options[2].getAttribute('aria-selected'), 'true')
+      assert.equal(input.getAttribute('aria-activedescendant'), 'hubot')
 
       press(input, 'Enter')
       assert.equal(expectedTargets.length, 2)
       assert.equal(expectedTargets[0], 'hubot')
-      assert.equal(expectedTargets[1], 'baymax')
+      assert.equal(expectedTargets[1], 'hubot')
     })
 
     it('fires commit events on click', function() {


### PR DESCRIPTION
Just like how `aria-disabled` elements [are ignored](https://github.com/github/auto-complete-element/blob/1751e45ba6989a8437783132293c6421a16e9ae1/src/autocomplete.js#L144) in https://github.github.com/auto-complete-element/examples/. 

