### PR TITLE
feat: export clearSelection

### DIFF
--- a/combobox-nav.js
+++ b/combobox-nav.js
@@ -109,7 +109,7 @@ export function navigate(
   }
 }
 
-export function clearSelection(input: HTMLElement | HTMLInputElement, list: HTMLElement): void {
+export function clearSelection(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): void {
   input.removeAttribute('aria-activedescendant')
   const target = list.querySelector('[aria-selected="true"]')
   if (!target) return

--- a/combobox-nav.js
+++ b/combobox-nav.js
@@ -34,7 +34,7 @@ function keyboardBindings(event: KeyboardEvent) {
       }
       break
     case 'Escape':
-      clearSelection(list)
+      clearSelection(input, list)
       break
     case 'ArrowDown':
       navigate(input, list, 1)
@@ -109,7 +109,8 @@ export function navigate(
   }
 }
 
-function clearSelection(list): void {
+export function clearSelection(input: HTMLElement | HTMLInputElement, list: HTMLElement): void {
+  input.removeAttribute('aria-activedescendant')
   const target = list.querySelector('[aria-selected="true"]')
   if (!target) return
   target.setAttribute('aria-selected', 'false')
@@ -123,5 +124,5 @@ function trackComposition(event: Event): void {
   const list = document.getElementById(input.getAttribute('aria-owns') || '')
   if (!list) return
 
-  clearSelection(list)
+  clearSelection(input, list)
 }

--- a/combobox-nav.js.flow
+++ b/combobox-nav.js.flow
@@ -3,3 +3,4 @@
 declare export function install(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): void;
 declare export function navigate(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement, indexDiff?: -1 | 1): void;
 declare export function uninstall(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): void;
+declare export function clearSelection(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): void;

--- a/test/test.js
+++ b/test/test.js
@@ -132,5 +132,20 @@ describe('combobox-nav', function() {
       assert(eventFired)
       assert.equal(window.location.hash, '#wall-e')
     })
+
+    it('clears aria-activedescendant and sets aria-selected=false when cleared', function() {
+      const input = document.querySelector('input')
+      const list = document.querySelector('ul')
+      const options = document.querySelectorAll('li')
+
+      press(input, 'ArrowDown')
+      assert.equal(options[0].getAttribute('aria-selected'), 'true')
+      assert.equal(input.getAttribute('aria-activedescendant'), 'baymax')
+
+      comboboxNav.clearSelection(input, list)
+
+      assert.equal(options[0].getAttribute('aria-selected'), 'false')
+      assert.equal(input.hasAttribute('aria-activedescendant'), false)
+    })
   })
 })


### PR DESCRIPTION
Sometimes it is useful to clear a selection for various events (like if the list contents change).

This PR exports the `clearSelection` function so we can use it upstream.