### PR TITLE
Introduce combobox-committed event

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,21 @@ uninstall(input, list)
 
 ## Events
 
-A bubbling `combobox-commit` event is fired on the list element when an option is selected via keyboard or click.
-
-For example, autocomplete when an option is selected:
+- `combobox-commit` (bubbles) - fired on the `role="option"` element when it is activated.
+- `combobox-committed` (bubbles) - fired on the `role="option"` element on the next tick of the activation event. This is useful for when the activation comes with side-effects like state changes that need to inspect afterward the fact.
 
 ```js
+list.addEventListener('click', function(event) {
+  noneSelectedMessage.hidden = true
+})
+
 list.addEventListener('combobox-commit', function(event) {
   console.log('Element selected: ', event.target)
+  if (!noneSelectedMessage.hidden) console.log('Message is not hidden.')
+})
+
+list.addEventListener('combobox-committed', function(event) {
+  if (noneSelectedMessage.hidden) console.log('Message is hidden now.')
 })
 ```
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -21,13 +21,27 @@
       <li><a id="wall-e" href="#wall-e" role="option">Wall-E</a></li>
     </ul>
   </form>
+  <div id="message">None selected. Please use type and select an option using keyboard.</div>
   <pre class="events"></pre>
   <script type="text/javascript">
-    comboboxNav.install(document.querySelector('input'), document.querySelector('ul'))
-
     const events = document.querySelector('.events')
-    document.addEventListener('combobox-commit', function(event) {
+    const input = document.querySelector('input')
+    const list = document.querySelector('ul')
+    const noneSelectedMessage = document.querySelector('#message')
+    comboboxNav.install(input, list)
+
+    list.addEventListener('click', function (event) {
+      noneSelectedMessage.hidden = true
+    })
+
+    list.addEventListener('combobox-commit', function (event) {
       events.append(`combobox-commit event on ${event.target.textContent}\n`)
+      console.log('Element selected: ', event.target)
+      if (!noneSelectedMessage.hidden) console.log('Message is not hidden.')
+    })
+
+    list.addEventListener('combobox-committed', function (event) {
+      if (noneSelectedMessage.hidden) console.log('Message is hidden now.')
     })
   </script>
 </body>

--- a/src/combobox-nav.js
+++ b/src/combobox-nav.js
@@ -66,7 +66,8 @@ function commitWithElement(event: MouseEvent) {
   const target = event.target.closest('[role="option"]')
   if (!target) return
   if (target.getAttribute('aria-disabled') === 'true') return
-  fireCommitEvent(target)
+  fireCommitEvent(target, 'combobox-commit')
+  setTimeout(() => fireCommitEvent(target, 'combobox-committed'), 0)
 }
 
 function commit(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): boolean {
@@ -77,9 +78,9 @@ function commit(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement
   return true
 }
 
-function fireCommitEvent(target: Element): void {
+function fireCommitEvent(target: Element, event: string): void {
   target.dispatchEvent(
-    new CustomEvent('combobox-commit', {
+    new CustomEvent(event, {
       bubbles: true
     })
   )

--- a/test/test.js
+++ b/test/test.js
@@ -2,10 +2,6 @@ function press(input, key, ctrlKey) {
   input.dispatchEvent(new KeyboardEvent('keydown', {key, ctrlKey}))
 }
 
-function click(element) {
-  element.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
-}
-
 describe('combobox-nav', function() {
   describe('with API', function() {
     beforeEach(function() {
@@ -90,7 +86,7 @@ describe('combobox-nav', function() {
       assert.equal(options[5].getAttribute('aria-selected'), 'true')
       assert.equal(input.getAttribute('aria-activedescendant'), 'wall-e')
       press(input, 'Enter')
-      click(options[5])
+      options[5].click()
 
       press(input, 'ArrowUp')
       assert.equal(options[3].getAttribute('aria-selected'), 'true')
@@ -114,9 +110,9 @@ describe('combobox-nav', function() {
         expectedTargets.push(target.id)
       })
 
-      click(options[2])
-      click(options[1])
-      click(options[0])
+      options[2].click()
+      options[1].click()
+      options[0].click()
 
       assert.equal(expectedTargets.length, 2)
       assert.equal(expectedTargets[0], 'hubot')
@@ -129,7 +125,7 @@ describe('combobox-nav', function() {
         eventFired = true
       })
 
-      click(document.querySelectorAll('[role=option]')[5])
+      document.querySelectorAll('[role=option]')[5].click()
       assert(eventFired)
       assert.equal(window.location.hash, '#wall-e')
     })

--- a/test/test.js
+++ b/test/test.js
@@ -166,4 +166,37 @@ describe('combobox-nav', function() {
       assert.equal(list.scrollTop, 36)
     })
   })
+
+  describe('with label/input as options', function() {
+    beforeEach(function() {
+      document.body.innerHTML = `
+        <input aria-owns="list-id" role="combobox" type="text">
+        <div id="list-id">
+          <label id="baymax" role="option"><input type="checkbox" value="Baymax" hidden> Baymax</label>
+          <label id="hubot" role="option"><input type="checkbox" value="Hubot" hidden> Hubot</label>
+          <label id="r2-d2" role="option"><input type="checkbox" value="R2-D2" hidden> R2-D2</label>
+        </div>
+      `
+      comboboxNav.install(document.querySelector('input'), document.querySelector('#list-id'))
+    })
+
+    afterEach(function() {
+      comboboxNav.uninstall(document.querySelector('input'), document.querySelector('#list-id'))
+      document.body.innerHTML = ''
+    })
+
+    it('fires event and input is checked', async function() {
+      const listener = new Promise(resolve => {
+        document.addEventListener('combobox-commit', () => {
+          assert(
+            document.querySelector('input[value="Hubot"]').checked,
+            'input should be checked when combobox-commit is fired'
+          )
+          resolve()
+        })
+      })
+      document.querySelectorAll('[role=option]')[1].click()
+      await listener
+    })
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -187,7 +187,7 @@ describe('combobox-nav', function() {
 
     it('fires event and input is checked', async function() {
       const listener = new Promise(resolve => {
-        document.addEventListener('combobox-commit', () => {
+        document.addEventListener('combobox-committed', () => {
           assert(
             document.querySelector('input[value="Hubot"]').checked,
             'input should be checked when combobox-commit is fired'


### PR DESCRIPTION
This adds a `combobox-committed` event to be fired on the next click in the event loop.

This is to fix an issue with using `<label>` as an option. When a `<label>` is clicked, the follow events are dispatched:
 
1. `click` on label
2. `combobox-commit` on `label`
3. `click` on labeled element
4. `change` on labeled element

`change` event is when the labeled element–the input– value is actually changed. This means if we inspect input value on `combobox-commit` the input value would be not have been changed. The new order is as follows:
 
1. `click` on label
2. `combobox-commit` on `label`
3. `click` on labeled element
4. `change` on labeled element
5. `combobox-committed` on `label`

This came up in https://github.com/github/github/pull/139530/files#diff-d6a0b025cbfcdc6f27cf56c120be4e07R100-R107.