### PR TITLE
Add a note about using labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ list.addEventListener('combobox-commit', function(event) {
 })
 ```
 
+**⚠ Note:** When using `<label>` + `<input>` as options, please listen on `change` instead of `combobox-commit`.
+
+When a label is clicked on, `click` event is fired from both `<label>` and its associated input `label.control`. Since combobox does not know about the control, `combobox-commit` cannot be used as an indicator of the item's selection state.
+
 ## Development
 
 ```


### PR DESCRIPTION
https://github.com/github/combobox-nav/pull/18#issuecomment-610051301

> > When a `<label>` is clicked, the follow events are dispatched:
> > 
> > 1. `click` on label
> > 2. `combobox-commit` on `label`
> > 3. `click` on labeled element
> > 4. **`combobox-commit` on `label`**
> > 5. `change` on labeled element
> 
> Because of this, `combobox-commit` is also getting fired twice.
> 
> I think this, plus the fact that if you are using `label > input`, `combobox-commit` event does not indicate selection*, we should just add a note saying you should listen on change instead `combobox-commit` when using `label > input`.
> 
> *To expand on "`combobox-commit` event does not indicate selection," I meant that if a checkbox's label was clicked on, it can either be checked or unchecked. At this point `combobox-nav` does not know what the state of the element is. To reliably detect this, user should listen on change event instead.

cc @CamiloGarciaLaRotta