### PR TITLE
[Breaking change] ARIA 1.2 Combobox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Combobox Navigation
 
-Attach [combobox navigation behavior](https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html) to `<input>` or `<textarea>`.
+Attach [combobox navigation behavior (ARIA 1.2)](https://www.w3.org/TR/wai-aria-1.2/#combobox) to `<input>`.
 
 ## Installation
 
@@ -15,15 +15,17 @@ $ npm install @github/combobox-nav
 ```html
 <label>
   Robot
-  <input id="robot-input" aria-owns="list-id" role="combobox" type="text">
+  <input id="robot-input" aria-controls="list-id" role="combobox" type="text" aria-expanded="false">
 </label>
-<ul role="listbox" id="list-id">
+<ul role="listbox" id="list-id" hidden>
   <li id="baymax" role="option">Baymax</li>
   <li><del>BB-8</del></li><!-- `role=option` needs to be present for item to be selectable -->
   <li id="hubot" role="option">Hubot</li>
   <li id="r2-d2" role="option">R2-D2</li>
 </ul>
 ```
+
+The combobox navigation pattern does not control list visibility. Please [refer to the ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#combobox) for more requirements around `aria-expanded` and `aria-autocomplete`.
 
 ### JS
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install @github/combobox-nav
 ```html
 <label>
   Robot
-  <input id="robot-input" aria-controls="list-id" role="combobox" type="text" aria-expanded="false">
+  <input id="robot-input" type="text">
 </label>
 <ul role="listbox" id="list-id" hidden>
   <li id="baymax" role="option">Baymax</li>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm install @github/combobox-nav
 </ul>
 ```
 
-The combobox navigation pattern does not control list visibility. Please [refer to the ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#combobox) for more requirements around `aria-expanded` and `aria-autocomplete`.
+`combobox-nav` will set all the necessary ARIA attributes on the elements at time of installation. However, since it does not control list visibility, please [refer to the ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#combobox) for more requirements around `aria-expanded` and `aria-autocomplete`.
 
 ### JS
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm install @github/combobox-nav
 </ul>
 ```
 
-`combobox-nav` will set all the necessary ARIA attributes on the elements at time of installation. However, since it does not control list visibility, please [refer to the ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#combobox) for more requirements around `aria-expanded` and `aria-autocomplete`.
+`combobox-nav` will set most of the necessary ARIA attributes on the elements at time of installation. However, since it does not control list visibility, please [refer to the ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#combobox) for more requirements around `aria-expanded` and `aria-autocomplete`.
 
 ### JS
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,7 +11,7 @@
   <form>
     <label>
       Least favorite robot
-      <input aria-owns="list-id" role="combobox" type="text">
+      <input aria-controls="list-id" role="combobox" type="text">
     </label>
     <ul role="listbox" id="list-id">
       <li id="baymax" role="option">Baymax</li>

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,14 +11,14 @@
   <form>
     <label>
       Least favorite robot
-      <input aria-controls="list-id" role="combobox" type="text">
+      <input aria-controls="list-id" role="combobox" type="text" aria-expanded="true">
     </label>
     <ul role="listbox" id="list-id">
       <li id="baymax" role="option">Baymax</li>
       <li id="bb-8" role="option" aria-disabled="true"><del>BB-8</del></li>
       <li id="hubot" role="option">Hubot</li>
       <li id="r2-d2" role="option">R2-D2</li>
-      <li><a id="wall-e" href="#wall-e" role="option">Wall-E</a></li>
+      <li role="presentation"><a id="wall-e" href="#wall-e" role="option">Wall-E</a></li>
     </ul>
   </form>
   <pre class="events"></pre>

--- a/src/combobox-nav.js
+++ b/src/combobox-nav.js
@@ -25,7 +25,7 @@ function keyboardBindings(event: KeyboardEvent) {
   const input = event.currentTarget
   if (!(input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement)) return
   if (isComposing) return
-  const list = document.getElementById(input.getAttribute('aria-owns') || '')
+  const list = document.getElementById(input.getAttribute('aria-controls') || '')
   if (!list) return
 
   switch (event.key) {
@@ -128,7 +128,7 @@ function trackComposition(event: Event): void {
   if (!(input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement)) return
   isComposing = event.type === 'compositionstart'
 
-  const list = document.getElementById(input.getAttribute('aria-owns') || '')
+  const list = document.getElementById(input.getAttribute('aria-controls') || '')
   if (!list) return
 
   clearSelection(input, list)

--- a/src/combobox-nav.js
+++ b/src/combobox-nav.js
@@ -3,6 +3,14 @@
 import {scrollTo} from './scroll'
 
 export function install(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): void {
+  if (!list.id) {
+    list.id = `combobox-${Math.random()
+      .toString()
+      .slice(2, 6)}`
+  }
+  input.setAttribute('role', 'combobox')
+  input.setAttribute('aria-controls', list.id)
+  if (!input.hasAttribute('aria-expanded')) input.setAttribute('aria-expanded', 'false')
   input.addEventListener('compositionstart', trackComposition)
   input.addEventListener('compositionend', trackComposition)
   input.addEventListener('keydown', keyboardBindings)
@@ -11,6 +19,9 @@ export function install(input: HTMLTextAreaElement | HTMLInputElement, list: HTM
 
 export function uninstall(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): void {
   input.removeAttribute('aria-activedescendant')
+  input.removeAttribute('role')
+  input.removeAttribute('aria-controls')
+  input.removeAttribute('aria-expanded')
   input.removeEventListener('compositionstart', trackComposition)
   input.removeEventListener('compositionend', trackComposition)
   input.removeEventListener('keydown', keyboardBindings)

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ describe('combobox-nav', function() {
   describe('with API', function() {
     beforeEach(function() {
       document.body.innerHTML = `
-        <input aria-owns="list-id" role="combobox" type="text">
+        <input aria-controls="list-id" role="combobox" type="text">
         <ul role="listbox" id="list-id">
           <li id="baymax" role="option">Baymax</li>
           <li><del>BB-8</del></li>
@@ -44,7 +44,7 @@ describe('combobox-nav', function() {
   describe('with default setup', function() {
     beforeEach(function() {
       document.body.innerHTML = `
-        <input aria-owns="list-id" role="combobox" type="text">
+        <input aria-controls="list-id" role="combobox" type="text">
         <ul role="listbox" id="list-id">
           <li id="baymax" role="option">Baymax</li>
           <li><del>BB-8</del></li>

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ describe('combobox-nav', function() {
   describe('with API', function() {
     beforeEach(function() {
       document.body.innerHTML = `
-        <input aria-controls="list-id" role="combobox" type="text">
+        <input type="text">
         <ul role="listbox" id="list-id">
           <li id="baymax" role="option">Baymax</li>
           <li><del>BB-8</del></li>
@@ -29,6 +29,10 @@ describe('combobox-nav', function() {
       const list = document.querySelector('ul')
       comboboxNav.install(input, list)
 
+      assert.equal(input.getAttribute('role'), 'combobox')
+      assert.equal(input.getAttribute('aria-expanded'), 'false')
+      assert.equal(input.getAttribute('aria-controls'), 'list-id')
+
       press(input, 'ArrowDown')
       assert.equal(list.children[0].getAttribute('aria-selected'), 'true')
       comboboxNav.navigate(input, list, 1)
@@ -44,7 +48,7 @@ describe('combobox-nav', function() {
   describe('with default setup', function() {
     beforeEach(function() {
       document.body.innerHTML = `
-        <input aria-controls="list-id" role="combobox" type="text">
+        <input type="text">
         <ul role="listbox" id="list-id">
           <li id="baymax" role="option">Baymax</li>
           <li><del>BB-8</del></li>


### PR DESCRIPTION
Ref: https://github.com/github/auto-complete-element/pull/41

https://github.com/w3c/aria/wiki/Resolving-ARIA-1.1-Combobox-Issues

> One way to fix all these problems is to eliminate the container and make the combobox more like a menubutton. This is essentially returning to the 1.0 pattern with one small modification -- use aria-controls to specify the input-popup relationship instead of aria-owns.

This changes `aria-owns` to `aria-controls`.

---

cc @jscholes This is the underlying module that powers auto-complete, which implements just the keyboard navigation with `aria-activedescendant`, not the filtering nor the expanding/collapsing. [Test page](https://html-is.glitch.me/github/combobox-nav-20.html#wall-e). Once this goes through I'll update https://github.com/github/auto-complete-element/pull/41 to remove `aria-owns`.