### PR TITLE
[Breaking changes] Rework combobox-nav APIs and use ARIA 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ import {clearSelection, install, navigate, start, stop, uninstall} from '@github
 const input = document.querySelector('#robot-input')
 const list = document.querySelector('#list-id')
 
-// To install combobox pattern on a given input and listbox
+// install combobox pattern on a given input and listbox
 install(input, list)
-// To start intercepting keyboard events for navigation
+// when options appear, start intercepting keyboard events for navigation
 start(input)
-// To stop intercepting keyboard events for navigation
+// when options disappear, stop intercepting keyboard events for navigation
 stop(input)
 
-// To move selection to the nth+1 item in the list
+// move selection to the nth+1 item in the list
 navigate(input, list, 1)
-// To reset selection
+// reset selection
 clearSelection(input, list)
-// To uninstall combobox pattern from the input
+// uninstall combobox pattern from the input
 uninstall(input)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Combobox Navigation
 
-Attach [combobox navigation behavior](https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html) to `<input>` or `<textarea>`.
+Attach [combobox navigation behavior (ARIA 1.2)](https://www.w3.org/TR/wai-aria-1.2/#combobox) to `<input>`.
 
 ## Installation
 
@@ -15,15 +15,17 @@ $ npm install @github/combobox-nav
 ```html
 <label>
   Robot
-  <input id="robot-input" aria-owns="list-id" role="combobox" type="text">
+  <input id="robot-input" aria-controls="list-id" role="combobox" type="text" aria-expanded="false">
 </label>
-<ul role="listbox" id="list-id">
+<ul role="listbox" id="list-id" hidden>
   <li id="baymax" role="option">Baymax</li>
   <li><del>BB-8</del></li><!-- `role=option` needs to be present for item to be selectable -->
   <li id="hubot" role="option">Hubot</li>
   <li id="r2-d2" role="option">R2-D2</li>
 </ul>
 ```
+
+The combobox navigation pattern does not control list visibility. Please [refer to the ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#combobox) for more requirements around `aria-expanded` and `aria-autocomplete`.
 
 ### JS
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install @github/combobox-nav
 ```html
 <label>
   Robot
-  <input id="robot-input" aria-controls="list-id" role="combobox" type="text" aria-expanded="false">
+  <input id="robot-input" type="text">
 </label>
 <ul role="listbox" id="list-id" hidden>
   <li id="baymax" role="option">Baymax</li>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm install @github/combobox-nav
 </ul>
 ```
 
-The combobox navigation pattern does not control list visibility. Please [refer to the ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#combobox) for more requirements around `aria-expanded` and `aria-autocomplete`.
+`combobox-nav` will set all the necessary ARIA attributes on the elements at time of installation. However, since it does not control list visibility, please [refer to the ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#combobox) for more requirements around `aria-expanded` and `aria-autocomplete`.
 
 ### JS
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm install @github/combobox-nav
 </ul>
 ```
 
-`combobox-nav` will set all the necessary ARIA attributes on the elements at time of installation. However, since it does not control list visibility, please [refer to the ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#combobox) for more requirements around `aria-expanded` and `aria-autocomplete`.
+`combobox-nav` will set most of the necessary ARIA attributes on the elements at time of installation. However, since it does not control list visibility, please [refer to the ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#combobox) for more requirements around `aria-expanded` and `aria-autocomplete`.
 
 ### JS
 

--- a/README.md
+++ b/README.md
@@ -25,23 +25,26 @@ $ npm install @github/combobox-nav
 </ul>
 ```
 
-`combobox-nav` will set most of the necessary ARIA attributes on the elements at time of installation. However, since it does not control list visibility, please [refer to the ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#combobox) for more requirements around `aria-expanded` and `aria-autocomplete`.
-
 ### JS
 
 ```js
-import {clearSelection, install, navigate, uninstall} from '@github/combobox-nav'
+import {clearSelection, install, navigate, start, stop, uninstall} from '@github/combobox-nav'
 const input = document.querySelector('#robot-input')
 const list = document.querySelector('#list-id')
 
-// To install this behavior
+// To install combobox pattern on a given input and listbox
 install(input, list)
+// To start intercepting keyboard events for navigation
+start(input)
+// To stop intercepting keyboard events for navigation
+stop(input)
+
 // To move selection to the nth+1 item in the list
 navigate(input, list, 1)
-// To clear selection
+// To reset selection
 clearSelection(input, list)
-// To uninstall this behavior
-uninstall(input, list)
+// To uninstall combobox pattern from the input
+uninstall(input)
 ```
 
 ## Events

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,7 +11,7 @@
   <form>
     <label>
       Least favorite robot
-      <input aria-owns="list-id" role="combobox" type="text">
+      <input aria-controls="list-id" role="combobox" type="text">
     </label>
     <ul role="listbox" id="list-id">
       <li id="baymax" role="option">Baymax</li>

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,9 +11,9 @@
   <form>
     <label>
       Least favorite robot
-      <input aria-controls="list-id" role="combobox" type="text" aria-expanded="true">
+      <input aria-controls="list-id" role="combobox" type="text">
     </label>
-    <ul role="listbox" id="list-id">
+    <ul role="listbox" id="list-id" hidden>
       <li id="baymax" role="option">Baymax</li>
       <li id="bb-8" role="option" aria-disabled="true"><del>BB-8</del></li>
       <li id="hubot" role="option">Hubot</li>
@@ -23,7 +23,25 @@
   </form>
   <pre class="events"></pre>
   <script type="text/javascript">
-    comboboxNav.install(document.querySelector('input'), document.querySelector('ul'))
+    const input = document.querySelector('input')
+    const list = document.querySelector('ul')
+    comboboxNav.install(input, list)
+
+    function toggleList() {
+      const hidden = input.value.length === 0
+      if (hidden) {
+        comboboxNav.stop(input)
+      } else {
+        comboboxNav.start(input)
+      }
+      list.hidden = hidden
+    }
+    input.addEventListener('input', toggleList)
+    input.addEventListener('focus', toggleList)
+    input.addEventListener('blur', () => {
+      list.hidden = true
+      comboboxNav.stop(input)
+    })
 
     const events = document.querySelector('.events')
     document.addEventListener('combobox-commit', function(event) {

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,14 +11,14 @@
   <form>
     <label>
       Least favorite robot
-      <input aria-controls="list-id" role="combobox" type="text">
+      <input aria-controls="list-id" role="combobox" type="text" aria-expanded="true">
     </label>
     <ul role="listbox" id="list-id">
       <li id="baymax" role="option">Baymax</li>
       <li id="bb-8" role="option" aria-disabled="true"><del>BB-8</del></li>
       <li id="hubot" role="option">Hubot</li>
       <li id="r2-d2" role="option">R2-D2</li>
-      <li><a id="wall-e" href="#wall-e" role="option">Wall-E</a></li>
+      <li role="presentation"><a id="wall-e" href="#wall-e" role="option">Wall-E</a></li>
     </ul>
   </form>
   <pre class="events"></pre>

--- a/src/combobox-nav.js
+++ b/src/combobox-nav.js
@@ -2,42 +2,70 @@
 
 import {scrollTo} from './scroll'
 
+const comboboxStates = new WeakMap()
+
 export function install(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): void {
+  if (comboboxStates.get(input)) {
+    uninstall(input)
+  }
+
   if (!list.id) {
     list.id = `combobox-${Math.random()
       .toString()
       .slice(2, 6)}`
   }
+
   input.setAttribute('role', 'combobox')
   input.setAttribute('aria-controls', list.id)
-  if (!input.hasAttribute('aria-expanded')) input.setAttribute('aria-expanded', 'false')
+  input.setAttribute('aria-expanded', 'false')
+  input.setAttribute('aria-autocomplete', 'list')
+  comboboxStates.set(input, {list, isComposing: false})
+}
+
+export function uninstall(input: HTMLTextAreaElement | HTMLInputElement): void {
+  const {list} = comboboxStates.get(input) || {}
+  if (!list) return
+  clearSelection(input, list)
+  stop(input)
+
+  input.removeAttribute('role')
+  input.removeAttribute('aria-controls')
+  input.removeAttribute('aria-expanded')
+  input.removeAttribute('aria-autocomplete')
+  comboboxStates.delete(input)
+}
+
+export function start(input: HTMLTextAreaElement | HTMLInputElement): void {
+  const {list} = comboboxStates.get(input) || {}
+  if (!list) return
+
+  input.setAttribute('aria-expanded', 'true')
   input.addEventListener('compositionstart', trackComposition)
   input.addEventListener('compositionend', trackComposition)
   input.addEventListener('keydown', keyboardBindings)
   list.addEventListener('click', commitWithElement)
 }
 
-export function uninstall(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): void {
+export function stop(input: HTMLTextAreaElement | HTMLInputElement): void {
+  const {list} = comboboxStates.get(input) || {}
+  if (!list) return
+
   input.removeAttribute('aria-activedescendant')
-  input.removeAttribute('role')
-  input.removeAttribute('aria-controls')
-  input.removeAttribute('aria-expanded')
+  input.setAttribute('aria-expanded', 'false')
   input.removeEventListener('compositionstart', trackComposition)
   input.removeEventListener('compositionend', trackComposition)
   input.removeEventListener('keydown', keyboardBindings)
   list.removeEventListener('click', commitWithElement)
 }
 
-let isComposing = false
 const ctrlBindings = !!navigator.userAgent.match(/Macintosh/)
 
 function keyboardBindings(event: KeyboardEvent) {
   if (event.shiftKey || event.metaKey || event.altKey) return
   const input = event.currentTarget
   if (!(input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement)) return
-  if (isComposing) return
-  const list = document.getElementById(input.getAttribute('aria-controls') || '')
-  if (!list) return
+  const {list, isComposing} = comboboxStates.get(input) || {}
+  if (!list || isComposing) return
 
   switch (event.key) {
     case 'Enter':
@@ -137,7 +165,9 @@ export function clearSelection(input: HTMLTextAreaElement | HTMLInputElement, li
 function trackComposition(event: Event): void {
   const input = event.currentTarget
   if (!(input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement)) return
-  isComposing = event.type === 'compositionstart'
+  const state = comboboxStates.get(input)
+  if (!state) return
+  state.isComposing = event.type === 'compositionstart'
 
   const list = document.getElementById(input.getAttribute('aria-controls') || '')
   if (!list) return

--- a/src/combobox-nav.js
+++ b/src/combobox-nav.js
@@ -25,7 +25,7 @@ function keyboardBindings(event: KeyboardEvent) {
   const input = event.currentTarget
   if (!(input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement)) return
   if (isComposing) return
-  const list = document.getElementById(input.getAttribute('aria-owns') || '')
+  const list = document.getElementById(input.getAttribute('aria-controls') || '')
   if (!list) return
 
   switch (event.key) {
@@ -128,7 +128,7 @@ function trackComposition(event: Event): void {
   if (!(input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement)) return
   isComposing = event.type === 'compositionstart'
 
-  const list = document.getElementById(input.getAttribute('aria-owns') || '')
+  const list = document.getElementById(input.getAttribute('aria-controls') || '')
   if (!list) return
 
   clearSelection(input, list)

--- a/src/combobox-nav.js
+++ b/src/combobox-nav.js
@@ -19,6 +19,7 @@ export function install(input: HTMLTextAreaElement | HTMLInputElement, list: HTM
   input.setAttribute('aria-controls', list.id)
   input.setAttribute('aria-expanded', 'false')
   input.setAttribute('aria-autocomplete', 'list')
+  input.setAttribute('aria-haspopup', 'listbox')
   comboboxStates.set(input, {list, isComposing: false})
 }
 
@@ -32,6 +33,7 @@ export function uninstall(input: HTMLTextAreaElement | HTMLInputElement): void {
   input.removeAttribute('aria-controls')
   input.removeAttribute('aria-expanded')
   input.removeAttribute('aria-autocomplete')
+  input.removeAttribute('aria-haspopup')
   comboboxStates.delete(input)
 }
 

--- a/src/combobox-nav.js
+++ b/src/combobox-nav.js
@@ -3,6 +3,14 @@
 import {scrollTo} from './scroll'
 
 export function install(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): void {
+  if (!list.id) {
+    list.id = `combobox-${Math.random()
+      .toString()
+      .slice(2, 6)}`
+  }
+  input.setAttribute('role', 'combobox')
+  input.setAttribute('aria-controls', list.id)
+  if (!input.hasAttribute('aria-expanded')) input.setAttribute('aria-expanded', 'false')
   input.addEventListener('compositionstart', trackComposition)
   input.addEventListener('compositionend', trackComposition)
   input.addEventListener('keydown', keyboardBindings)
@@ -11,6 +19,9 @@ export function install(input: HTMLTextAreaElement | HTMLInputElement, list: HTM
 
 export function uninstall(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): void {
   input.removeAttribute('aria-activedescendant')
+  input.removeAttribute('role')
+  input.removeAttribute('aria-controls')
+  input.removeAttribute('aria-expanded')
   input.removeEventListener('compositionstart', trackComposition)
   input.removeEventListener('compositionend', trackComposition)
   input.removeEventListener('keydown', keyboardBindings)

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ describe('combobox-nav', function() {
   describe('with API', function() {
     beforeEach(function() {
       document.body.innerHTML = `
-        <input aria-owns="list-id" role="combobox" type="text">
+        <input aria-controls="list-id" role="combobox" type="text">
         <ul role="listbox" id="list-id">
           <li id="baymax" role="option">Baymax</li>
           <li><del>BB-8</del></li>
@@ -44,7 +44,7 @@ describe('combobox-nav', function() {
   describe('with default setup', function() {
     beforeEach(function() {
       document.body.innerHTML = `
-        <input aria-owns="list-id" role="combobox" type="text">
+        <input aria-controls="list-id" role="combobox" type="text">
         <ul role="listbox" id="list-id">
           <li id="baymax" role="option">Baymax</li>
           <li><del>BB-8</del></li>

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,7 @@ function click(element) {
 
 describe('combobox-nav', function() {
   describe('with API', function() {
+    let input, list
     beforeEach(function() {
       document.body.innerHTML = `
         <input type="text">
@@ -18,34 +19,45 @@ describe('combobox-nav', function() {
           <li id="r2-d2" role="option">R2-D2</li>
         </ul>
       `
+      input = document.querySelector('input')
+      list = document.querySelector('ul')
     })
 
     afterEach(function() {
       document.body.innerHTML = ''
     })
 
-    it('installs, navigates, and uninstalls', function() {
-      const input = document.querySelector('input')
-      const list = document.querySelector('ul')
+    it('installs, starts, navigates, stops, and uninstalls', function() {
       comboboxNav.install(input, list)
-
       assert.equal(input.getAttribute('role'), 'combobox')
       assert.equal(input.getAttribute('aria-expanded'), 'false')
       assert.equal(input.getAttribute('aria-controls'), 'list-id')
+      assert.equal(input.getAttribute('aria-autocomplete'), 'list')
+
+      comboboxNav.start(input)
+      assert.equal(input.getAttribute('aria-expanded'), 'true')
 
       press(input, 'ArrowDown')
       assert.equal(list.children[0].getAttribute('aria-selected'), 'true')
       comboboxNav.navigate(input, list, 1)
       assert.equal(list.children[2].getAttribute('aria-selected'), 'true')
 
-      comboboxNav.uninstall(input, list)
-
+      comboboxNav.stop(input)
       press(input, 'ArrowDown')
       assert.equal(list.children[2].getAttribute('aria-selected'), 'true')
+
+      comboboxNav.uninstall(input)
+      assert.equal(list.children[2].getAttribute('aria-selected'), 'false')
+
+      assert(!input.hasAttribute('role'))
+      assert(!input.hasAttribute('aria-expanded'))
+      assert(!input.hasAttribute('aria-controls'))
+      assert(!input.hasAttribute('aria-autocomplete'))
     })
   })
 
   describe('with default setup', function() {
+    let input, list, options
     beforeEach(function() {
       document.body.innerHTML = `
         <input type="text">
@@ -59,17 +71,19 @@ describe('combobox-nav', function() {
           <li><a href="#wall-e" role="option">Wall-E</a></li>
         </ul>
       `
-      comboboxNav.install(document.querySelector('input'), document.querySelector('ul'))
+      input = document.querySelector('input')
+      list = document.querySelector('ul')
+      options = document.querySelectorAll('li')
+      comboboxNav.install(input, list)
+      comboboxNav.start(input)
     })
 
     afterEach(function() {
-      comboboxNav.uninstall(document.querySelector('input'), document.querySelector('ul'))
+      comboboxNav.uninstall(document.querySelector('input'))
       document.body.innerHTML = ''
     })
 
     it('updates attributes on keyboard events', function() {
-      const input = document.querySelector('input')
-      const options = document.querySelectorAll('li')
       const expectedTargets = []
 
       document.addEventListener('combobox-commit', function({target}) {
@@ -111,7 +125,6 @@ describe('combobox-nav', function() {
     })
 
     it('fires commit events on click', function() {
-      const options = document.querySelectorAll('li')
       const expectedTargets = []
 
       document.addEventListener('combobox-commit', function({target}) {
@@ -139,10 +152,6 @@ describe('combobox-nav', function() {
     })
 
     it('clears aria-activedescendant and sets aria-selected=false when cleared', function() {
-      const input = document.querySelector('input')
-      const list = document.querySelector('ul')
-      const options = document.querySelectorAll('li')
-
       press(input, 'ArrowDown')
       assert.equal(options[0].getAttribute('aria-selected'), 'true')
       assert.equal(input.getAttribute('aria-activedescendant'), 'baymax')
@@ -154,12 +163,9 @@ describe('combobox-nav', function() {
     })
 
     it('scrolls when the selected item is not in view', function() {
-      const input = document.querySelector('input')
-      const list = document.querySelector('ul')
       list.style.overflow = 'auto'
       list.style.height = '18px'
       list.style.position = 'relative'
-      const options = document.querySelectorAll('li')
       assert.equal(list.scrollTop, 0)
 
       press(input, 'ArrowDown')

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ describe('combobox-nav', function() {
   describe('with API', function() {
     beforeEach(function() {
       document.body.innerHTML = `
-        <input aria-controls="list-id" role="combobox" type="text">
+        <input type="text">
         <ul role="listbox" id="list-id">
           <li id="baymax" role="option">Baymax</li>
           <li><del>BB-8</del></li>
@@ -29,6 +29,10 @@ describe('combobox-nav', function() {
       const list = document.querySelector('ul')
       comboboxNav.install(input, list)
 
+      assert.equal(input.getAttribute('role'), 'combobox')
+      assert.equal(input.getAttribute('aria-expanded'), 'false')
+      assert.equal(input.getAttribute('aria-controls'), 'list-id')
+
       press(input, 'ArrowDown')
       assert.equal(list.children[0].getAttribute('aria-selected'), 'true')
       comboboxNav.navigate(input, list, 1)
@@ -44,7 +48,7 @@ describe('combobox-nav', function() {
   describe('with default setup', function() {
     beforeEach(function() {
       document.body.innerHTML = `
-        <input aria-controls="list-id" role="combobox" type="text">
+        <input type="text">
         <ul role="listbox" id="list-id">
           <li id="baymax" role="option">Baymax</li>
           <li><del>BB-8</del></li>

--- a/test/test.js
+++ b/test/test.js
@@ -33,6 +33,7 @@ describe('combobox-nav', function() {
       assert.equal(input.getAttribute('aria-expanded'), 'false')
       assert.equal(input.getAttribute('aria-controls'), 'list-id')
       assert.equal(input.getAttribute('aria-autocomplete'), 'list')
+      assert.equal(input.getAttribute('aria-haspopup'), 'listbox')
 
       comboboxNav.start(input)
       assert.equal(input.getAttribute('aria-expanded'), 'true')
@@ -53,6 +54,7 @@ describe('combobox-nav', function() {
       assert(!input.hasAttribute('aria-expanded'))
       assert(!input.hasAttribute('aria-controls'))
       assert(!input.hasAttribute('aria-autocomplete'))
+      assert(!input.hasAttribute('aria-haspopup'))
     })
   })
 


### PR DESCRIPTION
Summary of changes:

- `install()` has been renamed to `start()`, for use when options shows up
- `uninstall()` has been renamed `stop()`, for use when options are removed
- Newly added `install()` sets required ARIA attributes, for initialization
- Newly added `uninstall()` removes ARIA attributes, for breakdown

@jscholes This now adds an additional (required) call to set ARIA attributes; this was previously done inside of `<auto-complete>`'s element connected callback. I have one remaining question: Spec says to set `aria-haspopup`, but we've previously [gotten the feedback](https://github.com/github/details-dialog-element/issues/34) that [support for the attribute is poor for non-menu values](https://a11ysupport.io/tech/aria/aria-haspopup_attribute#expectations). Would you recommend that we leave that out still here? **EDIT**: looks like the spec says it's already implicitly set to listbox for elements with combobox role.
