### PR TITLE
Add support for Home and End keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,16 @@ function keyboardBindings(event: KeyboardEvent, combobox: Combobox) {
       combobox.navigate(-1)
       event.preventDefault()
       break
+    case 'Home':
+      combobox.clearSelection()
+      combobox.navigate(1)
+      event.preventDefault()
+      break
+    case 'End':
+      combobox.clearSelection()
+      combobox.navigate(-1)
+      event.preventDefault()
+      break
     case 'n':
       if (ctrlBindings && event.ctrlKey) {
         combobox.navigate(1)

--- a/test/test.js
+++ b/test/test.js
@@ -138,6 +138,14 @@ describe('combobox-nav', function() {
       assert.equal(options[5].getAttribute('aria-selected'), 'true')
       assert.equal(input.getAttribute('aria-activedescendant'), 'link')
 
+      press(input, 'Home')
+      assert.equal(options[0].getAttribute('aria-selected'), 'true')
+      assert.equal(input.getAttribute('aria-activedescendant'), 'baymax')
+
+      press(input, 'End')
+      assert.equal(options[5].getAttribute('aria-selected'), 'true')
+      assert.equal(input.getAttribute('aria-activedescendant'), 'link')
+
       press(input, 'Enter')
       assert.equal(expectedTargets.length, 2)
       assert.equal(expectedTargets[0], 'hubot')


### PR DESCRIPTION
The [WAI ARIA Practices 1.1][listbox-keyboard] outlines optional support
for [`Home` and `End` keys][keys] to jump to the top and bottom of the
listbox, respectively.

[listbox-keyboard]: https://www.w3.org/TR/wai-aria-practices-1.1/#listbox-popup-keyboard-interaction
[keys]: https://www.w3.org/TR/uievents-key/#keys-navigation