### PR TITLE
Allow any kind of element to be an input for a Combobox.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,12 @@ const ctrlBindings = !!navigator.userAgent.match(/Macintosh/)
 export default class Combobox {
   isComposing: boolean
   list: HTMLElement
-  input: HTMLTextAreaElement | HTMLInputElement
+  input: HTMLElement
   keyboardEventHandler: (event: KeyboardEvent) => void
   compositionEventHandler: (event: Event) => void
   inputHandler: (event: Event) => void
 
-  constructor(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement) {
+  constructor(input: HTMLElement, list: HTMLElement) {
     this.input = input
     this.list = list
     this.isComposing = false
@@ -144,7 +144,7 @@ function commitWithElement(event: MouseEvent) {
   fireCommitEvent(target)
 }
 
-function commit(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): boolean {
+function commit(input: HTMLElement, list: HTMLElement): boolean {
   const target = list.querySelector<HTMLElement>('[aria-selected="true"]')
   if (!target) return false
   if (target.getAttribute('aria-disabled') === 'true') return true


### PR DESCRIPTION
In order to use a rich text element as input for a Combobox, it needs to accept `HTMLElement`, not just `HTMLInputElement` or `HTMLTextArea`. Fortunately this works out of the box, and no changes are needed beyond changes to typing.