### PR TITLE
Make `Tab` insertion optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ list.addEventListener('combobox-commit', function(event) {
 
 When a label is clicked on, `click` event is fired from both `<label>` and its associated input `label.control`. Since combobox does not know about the control, `combobox-commit` cannot be used as an indicator of the item's selection state.
 
+## Settings
+
+For advanced configuration, the constructor takes an optional third argument. This is a settings object with the following setting:
+
+<dl>
+  <dt><code>tabInsertsSuggestions: boolean = true</code></dt>
+  <dd>Control whether the highlighted suggestion is inserted when <kbd>Tab</kbd> is pressed.</dd>
+</dl>
+
 ## Development
 
 ```

--- a/README.md
+++ b/README.md
@@ -72,10 +72,13 @@ When a label is clicked on, `click` event is fired from both `<label>` and its a
 
 For advanced configuration, the constructor takes an optional third argument. This is a settings object with the following setting:
 
-<dl>
-  <dt><code>tabInsertsSuggestions: boolean = true</code></dt>
-  <dd>Control whether the highlighted suggestion is inserted when <kbd>Tab</kbd> is pressed.</dd>
-</dl>
+- `tabInsertsSuggestions: boolean = true` -  Control whether the highlighted suggestion is inserted when <kbd>Tab</kbd> is pressed (<kbd>Enter</kbd> will always insert a suggestion regardless of this setting). When `true`, tab-navigation will be hijacked when open (which can have negative impacts on accessibility) but the combobox will more closely imitate a native IDE experience.
+
+For example:
+
+```js
+const combobox = new Combobox(input, list, {tabInsertsSuggestions: true})
+```
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,15 @@
+export type ComboboxSettings = {
+  /**
+   * Control whether pressing the `Tab` key should insert a suggestion (`Enter` will always
+   * insert a suggestion regardless of this setting). When `true`, tab-navigation will be
+   * hijacked when open (which can have negative impacts on accessibility) but the combobox
+   * will more closely imitate a native IDE experience.
+   *
+   * Defaults to `true`.
+   */
+  tabInsertsSuggestions?: boolean
+}
+
 export default class Combobox {
   isComposing: boolean
   list: HTMLElement
@@ -6,10 +18,17 @@ export default class Combobox {
   compositionEventHandler: (event: Event) => void
   inputHandler: (event: Event) => void
   ctrlBindings: boolean
+  tabInsertsSuggestions: boolean
 
-  constructor(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement) {
+  constructor(
+    input: HTMLTextAreaElement | HTMLInputElement,
+    list: HTMLElement,
+    {tabInsertsSuggestions}: ComboboxSettings = {}
+  ) {
     this.input = input
     this.list = list
+    this.tabInsertsSuggestions = tabInsertsSuggestions ?? true
+
     this.isComposing = false
 
     if (!list.id) {
@@ -103,8 +122,12 @@ function keyboardBindings(event: KeyboardEvent, combobox: Combobox) {
 
   switch (event.key) {
     case 'Enter':
-    case 'Tab':
       if (commit(combobox.input, combobox.list)) {
+        event.preventDefault()
+      }
+      break
+    case 'Tab':
+      if (combobox.tabInsertsSuggestions && commit(combobox.input, combobox.list)) {
         event.preventDefault()
       }
       break

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,4 @@
 export type ComboboxSettings = {
-  /**
-   * Control whether pressing the `Tab` key should insert a suggestion (`Enter` will always
-   * insert a suggestion regardless of this setting). When `true`, tab-navigation will be
-   * hijacked when open (which can have negative impacts on accessibility) but the combobox
-   * will more closely imitate a native IDE experience.
-   *
-   * Defaults to `true`.
-   */
   tabInsertsSuggestions?: boolean
 }
 


### PR DESCRIPTION
[WAI-ARIA recommendations for listboxes](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/#listbox-popup-keyboard-interaction) only specifies <kbd>Enter</kbd> as the key that should insert selected suggestions. Hijacking the <kbd>Tab</kbd> key unexpectedly can have negative impacts on user experience, particularly for users who use tabbing to navigate around the page.

At the same time, users may expect <kbd>Tab</kbd> to work based on their prior experience with IDEs.

To resolve this, I've added a settings object as a third parameter. In that settings object, the caller can pass a `tabInsertsSuggestions` option to control whether tab inserts suggestions or not. By default it does (to avoid breaking changes) but it can be overridden explicitly.

The settings object is fully optional to avoid breaking changes.

See also: second bullet point in this comment https://github.com/primer/react/pull/2157#issuecomment-1185626326
