### PR TITLE
Add setting for selecting first  option by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ $ npm install @github/combobox-nav
 ```html
 <label>
   Robot
-  <input id="robot-input" type="text">
+  <input id="robot-input" type="text" />
 </label>
 <ul role="listbox" id="list-id" hidden>
   <li id="baymax" role="option">Baymax</li>
-  <li><del>BB-8</del></li><!-- `role=option` needs to be present for item to be selectable -->
+  <li><del>BB-8</del></li>
+  <!-- `role=option` needs to be present for item to be selectable -->
   <li id="hubot" role="option">Hubot</li>
   <li id="r2-d2" role="option">R2-D2</li>
 </ul>
@@ -59,26 +60,28 @@ A bubbling `combobox-commit` event is fired on the list element when an option i
 For example, autocomplete when an option is selected:
 
 ```js
-list.addEventListener('combobox-commit', function(event) {
+list.addEventListener('combobox-commit', function (event) {
   console.log('Element selected: ', event.target)
 })
 ```
 
-**⚠ Note:** When using `<label>` + `<input>` as options, please listen on `change` instead of `combobox-commit`.
+> **Note** When using `<label>` + `<input>` as options, please listen on `change` instead of `combobox-commit`.
 
 When a label is clicked on, `click` event is fired from both `<label>` and its associated input `label.control`. Since combobox does not know about the control, `combobox-commit` cannot be used as an indicator of the item's selection state.
 
 ## Settings
 
-For advanced configuration, the constructor takes an optional third argument. This is a settings object with the following setting:
-
-- `tabInsertsSuggestions: boolean = true` -  Control whether the highlighted suggestion is inserted when <kbd>Tab</kbd> is pressed (<kbd>Enter</kbd> will always insert a suggestion regardless of this setting). When `true`, tab-navigation will be hijacked when open (which can have negative impacts on accessibility) but the combobox will more closely imitate a native IDE experience.
-
-For example:
+For advanced configuration, the constructor takes an optional third argument. For example:
 
 ```js
 const combobox = new Combobox(input, list, {tabInsertsSuggestions: true})
 ```
+
+These settings are available:
+
+- `tabInsertsSuggestions: boolean = true` - Control whether the highlighted suggestion is inserted when <kbd>Tab</kbd> is pressed (<kbd>Enter</kbd> will always insert a suggestion regardless of this setting). When `true`, tab-navigation will be hijacked when open (which can have negative impacts on accessibility) but the combobox will more closely imitate a native IDE experience.
+- `defaultFirstOption: boolean = false` - If no options are selected and the user presses <kbd>Enter</kbd>, should the first item be inserted? If enabled, the default option can be selected and styled with `[data-combobox-option-default]` . This should be styled differently from the `aria-selected` option.
+  > **Warning** Screen readers will not announce that the first item is the default. This should be announced explicitly with the use of `aria-live` status text.
 
 ## Development
 

--- a/test/test.js
+++ b/test/test.js
@@ -54,7 +54,7 @@ describe('combobox-nav', function () {
       assert(!list.querySelector('[aria-selected=true]'), 'Nothing should be selected')
 
       combobox.destroy()
-      assert.equal(list.children[2].getAttribute('aria-selected'), 'false')
+      assert.equal(list.children[2].getAttribute('aria-selected'), null)
 
       assert(!input.hasAttribute('role'))
       assert(!input.hasAttribute('aria-expanded'))
@@ -204,7 +204,7 @@ describe('combobox-nav', function () {
 
       combobox.clearSelection()
 
-      assert.equal(options[0].getAttribute('aria-selected'), 'false')
+      assert.equal(options[0].getAttribute('aria-selected'), null)
       assert.equal(input.hasAttribute('aria-activedescendant'), false)
     })
 
@@ -224,6 +224,69 @@ describe('combobox-nav', function () {
       assert.equal(options[1].getAttribute('aria-selected'), 'true')
       assert.equal(input.getAttribute('aria-activedescendant'), 'hubot')
       assert.equal(list.scrollTop, options[1].offsetTop)
+    })
+  })
+
+  describe('with defaulting to first option', function () {
+    let input
+    let list
+    let options
+    let combobox
+    beforeEach(function () {
+      document.body.innerHTML = `
+        <input type="text">
+        <ul role="listbox" id="list-id">
+          <li id="baymax" role="option">Baymax</li>
+          <li><del>BB-8</del></li>
+          <li id="hubot" role="option">Hubot</li>
+          <li id="r2-d2" role="option">R2-D2</li>
+          <li id="johnny-5" hidden role="option">Johnny 5</li>
+          <li id="wall-e" role="option" aria-disabled="true">Wall-E</li>
+          <li><a href="#link" role="option" id="link">Link</a></li>
+        </ul>
+      `
+      input = document.querySelector('input')
+      list = document.querySelector('ul')
+      options = document.querySelectorAll('[role=option]')
+      combobox = new Combobox(input, list, {defaultFirstOption: true})
+      combobox.start()
+    })
+
+    afterEach(function () {
+      combobox.destroy()
+      combobox = null
+      document.body.innerHTML = ''
+    })
+
+    it('indicates first option when started', () => {
+      assert.equal(document.querySelector('[data-combobox-option-default]'), options[0])
+      assert.equal(document.querySelectorAll('[data-combobox-option-default]').length, 1)
+    })
+
+    it('indicates first option when restarted', () => {
+      combobox.stop()
+      combobox.start()
+      assert.equal(document.querySelector('[data-combobox-option-default]'), options[0])
+    })
+
+    it('applies default option on Enter', () => {
+      let commits = 0
+      document.addEventListener('combobox-commit', () => commits++)
+
+      assert.equal(commits, 0)
+      press(input, 'Enter')
+      assert.equal(commits, 1)
+    })
+
+    it('clears default indication when navigating', () => {
+      combobox.navigate(1)
+      assert.equal(document.querySelectorAll('[data-combobox-option-default]').length, 0)
+    })
+
+    it('resets default indication when selection cleared', () => {
+      combobox.navigate(1)
+      combobox.clearSelection()
+      assert.equal(document.querySelectorAll('[data-combobox-option-default]').length, 1)
     })
   })
 })


### PR DESCRIPTION
Users often expect the first item in an autocomplete list to be inserted if they don't select anything and then hit <kbd>Enter</kbd>. For example, here's a video of this functionality in the GitHub emoji picker:


https://user-images.githubusercontent.com/2294248/179267706-930d5bca-a174-474e-82df-edf16c5f1c63.mov

---

This can be done with the current functionality by calling `navigate(1)` after `start()` or by setting `aria-selected` on the first item (to avoid setting the `activedescendant` and interrupting screen reader users). However, this has drawbacks. Users (particularly screen reader users) expect the _first_ item to be selected when they press <kbd>Down</kbd>, regardless of what the default is ([source](https://github.com/primer/react/pull/2157#issuecomment-1185626326)). 

A better solution is to style the first item using a different style to indicate that it will be inserted without actually selecting it (the following images are stolen from [our a11y docs](https://github.com/github/accessibility/blob/main/docs/coaching-recommendations/command-palette/list-semantics.md)):

![Screenshot of a combobox where the first option has a blue outline](https://user-images.githubusercontent.com/2294248/179268962-2f9df222-903f-4b55-ae9d-7ddcab2ccd3a.png)

Upon the first down arrow press, the first item will now be _selected_:

![Screenshot of a combobox where the first option has a blue fill](https://user-images.githubusercontent.com/2294248/179269115-04428b7b-b4d6-4fe2-81b1-171e139d5642.png)


---

That's what this change adds support for. This new feature is disabled by default and must be enabled by passing the `defaultFirstOption` setting. Then the consumer can style the default item by selecting for `data-combobox-option-default` (I chose to use a `data-*` attribute instead of a class for this because I didn't want to mess with the consumer's class list).

Note that there is no way to indicate this functionality using ARIA attributes, so it has to be announced explicitly using an `aria-live` message. A [demo implementation](https://github.github.com/auto-complete-element/examples/) of this is available from our own `auto-complete-element`. We could build that into the `Combobox` class, but I decided not to because we would have to be very opinionated about the message and implementation. Plus it would be difficult to internationalize.

