### PR TITLE
Fix `indicateDefaultOption` erroring when no options are visible

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export default class Combobox {
     if (this.defaultFirstOption) {
       Array.from(this.list.querySelectorAll<HTMLElement>('[role="option"]:not([aria-disabled="true"])'))
         .filter(visible)[0]
-        .setAttribute('data-combobox-option-default', 'true')
+        ?.setAttribute('data-combobox-option-default', 'true')
     }
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -288,5 +288,12 @@ describe('combobox-nav', function () {
       combobox.clearSelection()
       assert.equal(document.querySelectorAll('[data-combobox-option-default]').length, 1)
     })
+
+    it('does not error when no options are visible', () => {
+      assert.doesNotThrow(() => {
+        document.getElementById('list-id').style.display = 'none'
+        combobox.clearSelection()
+      })
+    })
   })
 })


### PR DESCRIPTION
When the list is hidden (ie, `display:none`), `indicateDefaultOption` is throwing an error:

> Cannot read properties of undefined (reading 'setAttribute')

The expected behavior is to do nothing in this case, as it's common to call `stop()` after hiding the list. When `start()` is called again, the default option will then be indicated.

This fixes the bug by using optional chaining to only call `setAttribute` if the element is found. Also added a test for this case.