### PR TITLE
Add a CommonJS build to the package

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist
 prettier.config.js
 karma.config.js
+dist-cjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
+dist-cjs/
 node_modules/

--- a/package.json
+++ b/package.json
@@ -2,9 +2,15 @@
   "name": "@github/combobox-nav",
   "description": "Attach combobox navigation behavior to an input.",
   "version": "2.1.5",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "module": "dist/index.js",
-  "type": "module",
+  "exports": {
+    ".": {
+      "node": "./dist-cjs/index.js",
+      "require": "./dist-cjs/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "types": "dist/index.d.ts",
   "license": "MIT",
   "repository": "github/combobox-nav",
@@ -16,7 +22,7 @@
     "clean": "rm -rf dist",
     "lint": "eslint .",
     "prebuild": "npm run clean && npm run lint && mkdir dist",
-    "build": "tsc",
+    "build": "tsc && tsc --module commonjs --outDir dist-cjs",
     "test": "karma start karma.config.cjs",
     "pretest": "npm run build",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
The lack of a CommonJS build is preventing this dependency from being used in applications using NextJS. By nature of `@primer/react` depending on this, that means `@primer/react` also cannot be used with NextJS (https://github.com/primer/react/issues/2245). To fix this, we need to add the the CommonJS build and configure package.json such that dependents will be able to locate the correct file.

This PR:

- Adds a CommonJS build outputted to `/dist-cjs`
- Adds `/dist-cjs` to `.gitignore`
- Adds the `exports` object to `package.json`
- Removes the `"type": "module"` field from `package.json` (not 100% sure on this one)

I don't have a good test environment setup for this unfortunately, so please do take a close look. I think this is right, based on looking at the build output, but I'm not completely confident.