### PR TITLE
Send original event details in combobox-commit CustomEvent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ function commitWithElement(event: MouseEvent) {
   const target = event.target.closest('[role="option"]')
   if (!target) return
   if (target.getAttribute('aria-disabled') === 'true') return
-  fireCommitEvent(target, event)
+  fireCommitEvent(target, {event})
 }
 
 function commit(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement): boolean {
@@ -184,8 +184,8 @@ function commit(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement
   return true
 }
 
-function fireCommitEvent(target: Element, originalEvent?: MouseEvent): void {
-  target.dispatchEvent(new CustomEvent('combobox-commit', {bubbles: true, detail: {originalEvent}}))
+function fireCommitEvent(target: Element, detail?: Record<string, unknown>): void {
+  target.dispatchEvent(new CustomEvent('combobox-commit', {bubbles: true, detail}))
 }
 
 function visible(el: HTMLElement): boolean {


### PR DESCRIPTION
I want to get some additional information about the originating trigger of the commit event (whether the `ctrlKey` or `metaKey` are pressed) to determine whether links should be opened in a new tab or not. Seems that information is not preserved in the `combobox-commit` CustomEvent.

I plumbed it through via details, lmk if you think this is reasonable