### PR TITLE
Introduce combobox-select event

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ list.addEventListener('combobox-commit', function (event) {
 
 When a label is clicked on, `click` event is fired from both `<label>` and its associated input `label.control`. Since combobox does not know about the control, `combobox-commit` cannot be used as an indicator of the item's selection state.
 
+A bubbling `combobox-select` event is fired on the list element when an option is selected but not yet committed.
+
+For example, autocomplete when an option is selected but not yet committed:
+
+```js
+list.addEventListener('combobox-select', function (event) {
+  console.log('Element selected : ', event.target)
+})
+```
+
 ## Settings
 
 For advanced configuration, the constructor takes an optional third argument. For example:

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ export default class Combobox {
       if (target === el) {
         this.input.setAttribute('aria-activedescendant', target.id)
         target.setAttribute('aria-selected', 'true')
+        fireSelectEvent(target)
         scrollTo(this.list, target)
       } else {
         el.removeAttribute('aria-selected')
@@ -186,6 +187,10 @@ function commit(input: HTMLTextAreaElement | HTMLInputElement, list: HTMLElement
 
 function fireCommitEvent(target: Element, detail?: Record<string, unknown>): void {
   target.dispatchEvent(new CustomEvent('combobox-commit', {bubbles: true, detail}))
+}
+
+function fireSelectEvent(target: Element): void {
+  target.dispatchEvent(new CustomEvent('combobox-select', {bubbles: true}))
 }
 
 function visible(el: HTMLElement): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,7 @@ function fireCommitEvent(target: Element, detail?: Record<string, unknown>): voi
 }
 
 function fireSelectEvent(target: Element): void {
-  target.dispatchEvent(new CustomEvent('combobox-select', {bubbles: true}))
+  target.dispatchEvent(new Event('combobox-select', {bubbles: true}))
 }
 
 function visible(el: HTMLElement): boolean {

--- a/test/test.js
+++ b/test/test.js
@@ -164,6 +164,21 @@ describe('combobox-nav', function () {
       assert.equal(expectedTargets[1], 'baymax')
     })
 
+    it('fires select events on navigating', function () {
+      const expectedTargets = []
+
+      document.addEventListener('combobox-select', function ({target}) {
+        expectedTargets.push(target.id)
+      })
+
+      press(input, 'ArrowDown')
+      press(input, 'ArrowDown')
+
+      assert.equal(expectedTargets.length, 2)
+      assert.equal(expectedTargets[0], 'baymax')
+      assert.equal(expectedTargets[1], 'hubot')
+    })
+
     it('clear selection on input operation', function () {
       press(input, 'ArrowDown')
       assert.equal(options[0].getAttribute('aria-selected'), 'true')


### PR DESCRIPTION
I added an event called `combobox-select` which is fired when an item is focused but not yet committed. 

This can be useful if you want to build an autocompletion while navigating through the options without actual committing a selection by hitting enter (similar to the spotlight search on mac-os). 

I hope this also sounds useful to you too.