### PR TITLE
Fix `FirstOptionSelectionMode`:`selected` clearing on typing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,6 @@ export default class Combobox {
     ;(this.input as HTMLElement).addEventListener('keydown', this.keyboardEventHandler)
     this.list.addEventListener('click', commitWithElement)
     this.indicateDefaultOption()
-    this.selectFirstItemIfNeeded()
   }
 
   stop(): void {
@@ -98,11 +97,7 @@ export default class Combobox {
       Array.from(this.list.querySelectorAll<HTMLElement>('[role="option"]:not([aria-disabled="true"])'))
         .filter(visible)[0]
         ?.setAttribute('data-combobox-option-default', 'true')
-    }
-  }
-
-  selectFirstItemIfNeeded(): void {
-    if (this.firstOptionSelectionMode === 'selected') {
+    } else if (this.firstOptionSelectionMode === 'selected') {
       this.navigate(1)
     }
   }
@@ -113,7 +108,7 @@ export default class Combobox {
     const focusIndex = els.indexOf(focusEl)
 
     if ((focusIndex === els.length - 1 && indexDiff === 1) || (focusIndex === 0 && indexDiff === -1)) {
-      this.clearSelection()
+      this.resetSelection()
       this.input.focus()
       return
     }
@@ -146,10 +141,11 @@ export default class Combobox {
     for (const el of this.list.querySelectorAll('[aria-selected="true"]')) {
       el.removeAttribute('aria-selected')
     }
+  }
 
-    if (this.firstOptionSelectionMode === 'active') {
-      this.indicateDefaultOption()
-    }
+  resetSelection(): void {
+    this.clearSelection()
+    this.indicateDefaultOption()
   }
 }
 
@@ -194,8 +190,7 @@ function keyboardBindings(event: KeyboardEvent, combobox: Combobox) {
       break
     default:
       if (event.ctrlKey) break
-      combobox.clearSelection()
-      combobox.selectFirstItemIfNeeded()
+      combobox.resetSelection()
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export default class Combobox {
       Array.from(this.list.querySelectorAll<HTMLElement>('[role="option"]:not([aria-disabled="true"])'))
         .filter(visible)[0]
         ?.setAttribute('data-combobox-option-default', 'true')
-    } else if (this.firstOptionSelectionMode === 'selected') {
+    } else if (this.firstOptionSelectionMode === 'selected' && visible(this.list)) {
       this.navigate(1)
     }
   }
@@ -142,9 +142,7 @@ export default class Combobox {
       el.removeAttribute('aria-selected')
     }
 
-    if (this.firstOptionSelectionMode === 'active') {
-      this.indicateDefaultOption()
-    }
+    this.indicateDefaultOption()
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ export default class Combobox {
     ;(this.input as HTMLElement).addEventListener('keydown', this.keyboardEventHandler)
     this.list.addEventListener('click', commitWithElement)
     this.indicateDefaultOption()
+    this.selectFirstItemIfNeeded()
   }
 
   stop(): void {
@@ -97,7 +98,11 @@ export default class Combobox {
       Array.from(this.list.querySelectorAll<HTMLElement>('[role="option"]:not([aria-disabled="true"])'))
         .filter(visible)[0]
         ?.setAttribute('data-combobox-option-default', 'true')
-    } else if (this.firstOptionSelectionMode === 'selected' && visible(this.list)) {
+    }
+  }
+
+  selectFirstItemIfNeeded(): void {
+    if (this.firstOptionSelectionMode === 'selected') {
       this.navigate(1)
     }
   }
@@ -142,7 +147,9 @@ export default class Combobox {
       el.removeAttribute('aria-selected')
     }
 
-    this.indicateDefaultOption()
+    if (this.firstOptionSelectionMode === 'active') {
+      this.indicateDefaultOption()
+    }
   }
 }
 
@@ -188,6 +195,7 @@ function keyboardBindings(event: KeyboardEvent, combobox: Combobox) {
     default:
       if (event.ctrlKey) break
       combobox.clearSelection()
+      combobox.selectFirstItemIfNeeded()
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -308,10 +308,16 @@ describe('combobox-nav', function () {
       assert.equal(document.querySelectorAll('[data-combobox-option-default]').length, 0)
     })
 
-    it('resets default indication when selection cleared', () => {
+    it('resets default indication when selection reset', () => {
+      combobox.navigate(1)
+      combobox.resetSelection()
+      assert.equal(document.querySelectorAll('[data-combobox-option-default]').length, 1)
+    })
+
+    it('removes default indication when selection cleared', () => {
       combobox.navigate(1)
       combobox.clearSelection()
-      assert.equal(document.querySelectorAll('[data-combobox-option-default]').length, 1)
+      assert.equal(document.querySelectorAll('[data-combobox-option-default]').length, 0)
     })
 
     it('does not error when no options are visible', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -285,6 +285,15 @@ describe('combobox-nav', function () {
       assert.equal(document.querySelector('[data-combobox-option-default]'), options[0])
     })
 
+    it('first item remains active when typing', () => {
+      const text = 'R2-D2'
+      for (let i = 0; i < text.length; i++) {
+        press(input, text[i])
+      }
+
+      assert.equal(document.querySelector('[data-combobox-option-default]'), options[0])
+    })
+
     it('applies default option on Enter', () => {
       let commits = 0
       document.addEventListener('combobox-commit', () => commits++)
@@ -346,6 +355,15 @@ describe('combobox-nav', function () {
       // Does not set the default attribute
       assert.equal(document.querySelectorAll('[data-combobox-option-default]').length, 0)
       // Item is correctly selected
+      assert.equal(list.children[0].getAttribute('aria-selected'), 'true')
+    })
+
+    it('first item remains selected when typing', () => {
+      const text = 'R2-D2'
+      for (let i = 0; i < text.length; i++) {
+        press(input, text[i])
+      }
+
       assert.equal(list.children[0].getAttribute('aria-selected'), 'true')
     })
 


### PR DESCRIPTION
When the `FirstOptionSelectionMode` prop is set to `selected`, this would correctly set the first element to selected on open, but on typing, remove this state.

This was easily reproducible with a test-case that I should have had in my prior PR here: https://github.com/github/combobox-nav/pull/81

To encourage a simple code path that's shared with the `active` state for `FirstOptionSelectionMode`, I refactored the code a bit and also cleaned up some call paths that were not necessary on closing flows.

This PR adds:
- Many tests
- A new method, `resetSelection` to be distinct from `clearSelection`. Why?
  - Previously, `clearSelection` also handled the "state reset" for active/selected state, but this broken in the case for "active" as it would try to navigate when the list was not visible, as `clearSelection` was called on `.stop`, `.destroy` etc. This flow didn't make sense, but didn't throw errors for the `active` state as there was no navigations on option lists but rather attribute settings.
  - This new flow now explicitly calls `resetSelection` when appropriate, which is, on non-special character typing. (First open is applicable, but we call `indicateDefaultOption` directly.