### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/github/combobox-nav/security/code-scanning/2](https://github.com/github/combobox-nav/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block defining the minimum needed permissions for this workflow. Since the workflow only checks out code and runs builds/tests (not publishing, releasing, or any steps requiring write permissions), it likely only needs read-level access to repository contents. The change can be implemented by inserting a `permissions:` block at the workflow root (above `jobs:`). Editing the `.github/workflows/nodejs.yml` file, add:

```yaml
permissions:
  contents: read
```

at line 10 (after the `on:` block and before `jobs:`). No additional imports, definitions, or changes are needed elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
