### PR TITLE
Add automatic combobox item ID

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,9 @@ export default class Combobox {
       el.removeAttribute('data-combobox-option-default')
 
       if (target === el) {
+        if (!target.id) {
+          target.id = `combobox-item-${Math.random().toString().slice(2, 6)}`
+        }
         this.input.setAttribute('aria-activedescendant', target.id)
         target.setAttribute('aria-selected', 'true')
         fireSelectEvent(target)


### PR DESCRIPTION
This is a demo of one possible solution to https://github.com/github/combobox-nav/issues/96. In the screen recording below you can see random IDs being automatically added to each option in order to give `aria-activedescendant` something to point at.

https://github.com/user-attachments/assets/560029d0-9cbf-417b-83ad-5919a7d286e7

The big upside of this approach is that it amounts to an automated retrofit for any and all ARIA widget implementations that use this package and omit the IDs on the options. Applications using this package would get an accessibility upgrade free via dependabot.

One downside I can think of is that the risk of ID collisions grows with both the length of the list and the number of other lists on the page. If you had five comboboxes with 100 elements each on the same page you'd have a 50/50 chance of a collision with the code I've written here. We can easily improve those odds by incorporating `list.id` into `target.id` and adding more random digits, though.

Another downside is the potential for further screen reader bugs due to the last-minute insertion of the random IDs. It works fine in VoiceOver in the screen recording above, but my gut feeling is that results may vary in a screen reader like JAWS due to the last-minute nature of the change. If you want to move forward with this approach I can commit to manually testing it in JAWS first. If there is an issue there, we can fix it by moving the ID generation into the constructor alongside the one for `list.id` so that JAWS has time to notice them.