### PR TITLE
Add console warning about missing IDs on options

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,18 @@ These settings are available:
 npm install
 npm test
 ```
+
+## Troubleshooting
+
+### Combobox options must have unique IDs
+
+Passing a combobox whose options lack IDs results in the following console warning.
+
+> Combobox options must have unique IDs
+> See https://github.com/github/combobox-nav/?tab=readme-ov-file#combobox-options-must-have-unique-ids
+
+Without the IDs we lack a unique identifier for [`aria-activedescendant`](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_focus_activedescendant) to reference. As a result, screen readers are unable to announce which option is currently selected.
+
+You can remove this warning by setting IDs on every option in the combobox.
+
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,13 @@ export default class Combobox {
       list.id = `combobox-${Math.random().toString().slice(2, 6)}`
     }
 
+    if (list.querySelectorAll('[role="option"]:not([id])').length > 0) {
+      console.warn([
+        'Combobox options must have unique IDs',
+        'See https://github.com/github/combobox-nav/?tab=readme-ov-file#combobox-options-must-have-unique-ids',
+      ].join('\n'))
+    }
+
     this.ctrlBindings = !!navigator.userAgent.match(/Macintosh/)
 
     this.keyboardEventHandler = event => keyboardBindings(event, this)


### PR DESCRIPTION
This is another alternative approach to https://github.com/github/combobox-nav/issues/96. Instead of attempting a fix, we detect the issue in the constructor and print a console warning with a brief message and a URL linking to further documentation.

<img width="1440" height="828" alt="Devtools screenshot where options lack IDs and in the console below a warning about the issue is shown" src="https://github.com/user-attachments/assets/1963472a-f925-4ba6-9c33-ecd1f8ef6dfd" />

The big upside with this approach is its conservative nature. Backwards compatibility is maximised by avoiding any material changes to the behaviour of the component.

One downside is the risk of downstream maintainers ignoring the warning forever and never resolving their accessibility issue. Another is that on high-traffic sites with an error tracking service Sentry, the large volume of sudden new warnings might exhaust some people's quotas, which could be a bit of an unwelcome headache.