### PR TITLE
Automatically set an ID on active combobox options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,11 +126,17 @@ export default class Combobox {
       el.removeAttribute('data-combobox-option-default')
 
       if (target === el) {
+        if (!target.id) {
+          target.id = `${this.list.id}-selected`
+        }
         this.input.setAttribute('aria-activedescendant', target.id)
         target.setAttribute('aria-selected', 'true')
         fireSelectEvent(target)
         target.scrollIntoView(this.scrollIntoViewOptions)
       } else {
+        if (el.id === `${this.list.id}-selected`) {
+          el.removeAttribute('id');
+        }
         el.removeAttribute('aria-selected')
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export default class Combobox {
   tabInsertsSuggestions: boolean
   firstOptionSelectionMode: FirstOptionSelectionMode
   scrollIntoViewOptions?: boolean | ScrollIntoViewOptions
+  didAutoAssignLastSelectedId: boolean
 
   constructor(
     input: HTMLTextAreaElement | HTMLInputElement,
@@ -44,6 +45,7 @@ export default class Combobox {
     this.scrollIntoViewOptions = scrollIntoViewOptions ?? {block: 'nearest', inline: 'nearest'}
 
     this.isComposing = false
+    this.didAutoAssignLastSelectedId = false
 
     if (!list.id) {
       list.id = `combobox-${Math.random().toString().slice(2, 6)}`
@@ -128,14 +130,16 @@ export default class Combobox {
       if (target === el) {
         if (!target.id) {
           target.id = `${this.list.id}-selected`
+          this.didAutoAssignLastSelectedId = true
         }
         this.input.setAttribute('aria-activedescendant', target.id)
         target.setAttribute('aria-selected', 'true')
         fireSelectEvent(target)
         target.scrollIntoView(this.scrollIntoViewOptions)
       } else {
-        if (el.id === `${this.list.id}-selected`) {
-          el.removeAttribute('id');
+        if (el.id === `${this.list.id}-selected` && this.didAutoAssignLastSelectedId) {
+          el.removeAttribute('id')
+          this.didAutoAssignLastSelectedId = false
         }
         el.removeAttribute('aria-selected')
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,10 @@ export default class Combobox {
     for (const el of this.list.querySelectorAll('[aria-selected="true"], [data-combobox-option-default="true"]')) {
       el.removeAttribute('aria-selected')
       el.removeAttribute('data-combobox-option-default')
+      if (el.id === `${this.list.id}-selected` && this.didAutoAssignLastSelectedId) {
+        el.removeAttribute('id')
+        this.didAutoAssignLastSelectedId = false
+      }
     }
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -410,4 +410,46 @@ describe('combobox-nav', function () {
       })
     })
   })
+
+  describe('with missing IDs on options', function () {
+    let input
+    let list
+    beforeEach(function () {
+      document.body.innerHTML = `
+        <input type="text">
+        <ul role="listbox" id="list-id">
+          <li role="option">Baymax</li>
+          <li id="hubot" role="option">Hubot</li>
+          <li role="option">R2-D2</li>
+        </ul>
+      `
+      input = document.querySelector('input')
+      list = document.querySelector('ul')
+    })
+
+    afterEach(function () {
+      document.body.innerHTML = ''
+    })
+
+    it('automatically adds and removes option IDs when needed for aria-activedescendant', function () {
+      const combobox = new Combobox(input, list)
+      combobox.start()
+      assert.equal(input.getAttribute('aria-expanded'), 'true')
+
+      press(input, 'ArrowDown')
+      assert.equal(list.children[0].getAttribute('id'), 'list-id-selected')
+      assert.equal(list.children[1].getAttribute('id'), 'hubot')
+      assert.equal(list.children[2].getAttribute('id'), undefined)
+
+      press(input, 'ArrowDown')
+      assert.equal(list.children[0].getAttribute('id'), undefined)
+      assert.equal(list.children[1].getAttribute('id'), 'hubot')
+      assert.equal(list.children[2].getAttribute('id'), undefined)
+
+      press(input, 'ArrowDown')
+      assert.equal(list.children[0].getAttribute('id'), undefined)
+      assert.equal(list.children[1].getAttribute('id'), 'hubot')
+      assert.equal(list.children[2].getAttribute('id'), 'list-id-selected')
+    })
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -453,6 +453,12 @@ describe('combobox-nav', function () {
       assert.equal(list.children[0].getAttribute('id'), undefined)
       assert.equal(list.children[1].getAttribute('id'), 'hubot')
       assert.equal(list.children[2].getAttribute('id'), 'list-id-selected')
+
+      press(input, 'Escape')
+      assert.equal(input.getAttribute('aria-activedescendant'), undefined)
+      assert.equal(list.children[0].getAttribute('id'), undefined)
+      assert.equal(list.children[1].getAttribute('id'), 'hubot')
+      assert.equal(list.children[2].getAttribute('id'), undefined)
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -437,16 +437,19 @@ describe('combobox-nav', function () {
       assert.equal(input.getAttribute('aria-expanded'), 'true')
 
       press(input, 'ArrowDown')
+      assert.equal(input.getAttribute('aria-activedescendant'), 'list-id-selected')
       assert.equal(list.children[0].getAttribute('id'), 'list-id-selected')
       assert.equal(list.children[1].getAttribute('id'), 'hubot')
       assert.equal(list.children[2].getAttribute('id'), undefined)
 
       press(input, 'ArrowDown')
+      assert.equal(input.getAttribute('aria-activedescendant'), 'hubot')
       assert.equal(list.children[0].getAttribute('id'), undefined)
       assert.equal(list.children[1].getAttribute('id'), 'hubot')
       assert.equal(list.children[2].getAttribute('id'), undefined)
 
       press(input, 'ArrowDown')
+      assert.equal(input.getAttribute('aria-activedescendant'), 'list-id-selected')
       assert.equal(list.children[0].getAttribute('id'), undefined)
       assert.equal(list.children[1].getAttribute('id'), 'hubot')
       assert.equal(list.children[2].getAttribute('id'), 'list-id-selected')


### PR DESCRIPTION
This is my third and final idea for a solution to https://github.com/github/combobox-nav/issues/96. It also happens to be my favourite, because it's the approach in https://www.w3.org/TR/wai-aria-1.2/#example-6. In the screen recording below, we can see the ID `list-id-selected` being automatically applied to each option in turn as it's selected.

https://github.com/user-attachments/assets/76979fed-b9e0-4634-b938-9ab7a8d0734d

It has the same upsides as https://github.com/github/combobox-nav/pull/97 without the downside of the increased risk of collisions. And since it's a direct copy of the approach in one of the examples in the ARIA spec itself I'm less concerned about the possibility of an issue with JAWS than I was with https://github.com/github/combobox-nav/pull/97.